### PR TITLE
Update extra ignition allocation for SSim3

### DIFF
--- a/src/growth-cell2fire.R
+++ b/src/growth-cell2fire.R
@@ -198,7 +198,7 @@ getRunContext <- function() {
   isParallel <- libraryPath %>%
     str_split("/|(\\\\)") %>%
     pluck(1) %>%
-    str_detect("Parallel") %>%
+    str_detect("MultiProc") %>%
     any %>%
     `&`(str_detect(libraryName, "Job-\\d"))
   


### PR DESCRIPTION
Current version was missing a change to support SSim 3.0's change in how multiprocessed contexts are named.

Leads to every job running every extra ignition.