### PR TITLE
Burn Perimeter, FBP Outputs, and Resampling Record Keeping Update

### DIFF
--- a/src/.metadata
+++ b/src/.metadata
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package builtForSyncroSimVersion="3.1.9" />

--- a/src/growth-cell2fire.R
+++ b/src/growth-cell2fire.R
@@ -63,7 +63,8 @@ GreenUp <- datasheet(myScenario, "burnP3Plus_GreenUp", lookupsAsFactors = F, opt
 Curing <- datasheet(myScenario, "burnP3Plus_Curing", lookupsAsFactors = F, optional = T)
 FuelLoad <- datasheet(myScenario, "burnP3Plus_FuelLoad", lookupsAsFactors = F, optional = T)
 OutputOptions <- datasheet(myScenario, "burnP3Plus_OutputOption", optional = T)
-OutputOptionsSpatial <- datasheet(myScenario, "burnP3Plus_OutputOptionSpatial", optional = T)
+OutputOptionsSpatial <- datasheet(myScenario, "burnP3Plus_OutputOptionSpatial", optional = T) %>% mutate(BurnPerimeter = as.character(BurnPerimeter))
+OutputOptionFBPSpatial <- datasheet(myScenario, "burnP3Plus_OutputOptionFBPSpatial", optional = T, returnInvisible = T) %>% mutate(Variable = as.character(Variable))
 FireZoneTable <- datasheet(myScenario, "burnP3Plus_FireZone")
 WeatherZoneTable <- datasheet(myScenario, "burnP3Plus_WeatherZone")
 
@@ -103,13 +104,15 @@ if(isDatasheetEmpty(OutputOptions)) {
 }
 
 if(isDatasheetEmpty(OutputOptionsSpatial)) {
-  updateRunLog("No spatial output options chosen. Defaulting to keeping all spatial outputs.", type = "info")
+  updateRunLog("No spatial output options chosen. Defaulting to keeping all spatial outputs and final burn perimeters.", type = "info")
   OutputOptionsSpatial[1,] <- rep(TRUE, length(OutputOptionsSpatial[1,]))
+  OutputOptionsSpatial$BurnPerimeter <- "Final"
   saveDatasheet(myScenario, OutputOptionsSpatial, "burnP3Plus_OutputOptionSpatial")
 } else if (any(is.na(OutputOptionsSpatial))) {
   updateRunLog("Missing one or more spatial output options. Defaulting to keeping unspecified spatial outputs.", type = "info")
   OutputOptionsSpatial <- OutputOptionsSpatial %>%
     replace(is.na(.), TRUE)
+  OutputOptionsSpatial$BurnPerimeter <- replace(OutputOptionsSpatial$BurnPerimeter, OutputOptionsSpatial$BurnPerimeter == TRUE, "Final")
   saveDatasheet(myScenario, OutputOptionsSpatial, "burnP3Plus_OutputOptionSpatial")
 }
 
@@ -133,6 +136,10 @@ if(isDatasheetEmpty(WeatherZoneTable))
 # Handle unsupported inputs
 if(!isDatasheetEmpty(WindGrid)) {
   updateRunLog("Cell2Fire currently does not support Wind Grids. Wind Grid options ignored.", type = "info")
+}
+
+if(!isDatasheetEmpty(OutputOptionFBPSpatial)) {
+  updateRunLog("Cell2Fire currently does not support spatial FBP outputs. Spatial FBP output options ignored.", type = "info")
 }
 
 if(!isDatasheetEmpty(GreenUp)) {
@@ -901,7 +908,7 @@ if(OutputOptionsSpatial$AllPerim | (saveBurnMaps & minimumFireSize > 0)){
 
 
 ## Burn perimeters ----
-if(OutputOptionsSpatial$BurnPerimeter) {
+if(OutputOptionsSpatial$BurnPerimeter != "No") {
   updateRunLog("Cell2Fire does not provide burn perimeters.", type = "info")
 }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package name="burnP3PlusCell2Fire" displayName= "BurnP3+ Cell2Fire" description= "Cell2Fire fire growth model for BurnP3+" version="2.2.0" url="https://github.com/BurnP3/BurnP3PlusCell2Fire" minSyncroSimVersion="3.1.0">
+<package name="burnP3PlusCell2Fire" displayName= "BurnP3+ Cell2Fire" description= "Cell2Fire fire growth model for BurnP3+" version="2.1.0" url="https://github.com/BurnP3/BurnP3PlusCell2Fire">
 
-	<builtFor package = "burnP3Plus" version = "2.3.0"/>
+	<builtFor package = "burnP3Plus" version = "2.2.0"/>
 
 	<!--Project Datasheets-->
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package name="burnP3PlusCell2Fire" displayName= "BurnP3+ Cell2Fire" description= "Cell2Fire fire growth model for BurnP3+" version="2.1.0" url="https://github.com/BurnP3/BurnP3PlusCell2Fire">
+<package name="burnP3PlusCell2Fire" displayName= "BurnP3+ Cell2Fire" description= "Cell2Fire fire growth model for BurnP3+" version="2.3.0" url="https://github.com/BurnP3/BurnP3PlusCell2Fire">
 
-	<builtFor package = "burnP3Plus" version = "2.2.0"/>
+	<builtFor package = "burnP3Plus" version = "2.4.0"/>
 
 	<!--Project Datasheets-->
 


### PR DESCRIPTION
Please see the accompanying beta release and BP3+ beta release for a summary of changes and release files to test against:

https://github.com/BurnP3/BurnP3PlusCell2Fire/releases/tag/2.3.0
https://github.com/BurnP3/BurnP3Plus/releases/tag/2.4.0

Please also note you will need SyncroSim v3.1.9 for this release.
